### PR TITLE
Apply fixes

### DIFF
--- a/test/test_pdict.c
+++ b/test/test_pdict.c
@@ -51,7 +51,7 @@ void test_isEmpty_ShouldReturnTrueOnAnEmptyDict(void) {
 
 void test_size_SizeOfNewDictWithOneItemShouldBeOne(void) {
     char *_key = malloc(KEYS_LEN);
-    size_t* _data = 0;
+    size_t _data = 0;
     snprintf(_key, KEYS_LEN, "%s", "0_key");
     pdict_put(D, keys[0], &_data);
     TEST_ASSERT_EQUAL_UINT(pdict_size(D), 1);
@@ -79,7 +79,7 @@ void test_size_ShouldNotBeZeroAfterAddingElements(void) {
 
 void test_add_ShouldAddANewElement(void) {
     char *_key = malloc(KEYS_LEN);
-    size_t* _data = 99;
+    size_t _data = 99;
     snprintf(_key, KEYS_LEN, "%s", "99_key");
     TEST_ASSERT_TRUE(pdict_is_empty(D));
     pdict_put(D, _key, &_data);
@@ -90,9 +90,9 @@ void test_add_ShouldAddANewElement(void) {
 void test_append_ShouldAddAnElementToAnEmptyDict(void) {
     char* _key = malloc(KEYS_LEN);
     snprintf(_key, KEYS_LEN, "%s", "1_key");
-    size_t* _data = 1;
+    size_t _data = 1;
     TEST_ASSERT_TRUE(pdict_is_empty(D));
-    pdict_put(D, _key, _data);
+    pdict_put(D, _key, &_data);
     TEST_ASSERT_FALSE(pdict_is_empty(D));
     free(_key);
 }

--- a/test/test_pdict.c
+++ b/test/test_pdict.c
@@ -51,7 +51,7 @@ void test_isEmpty_ShouldReturnTrueOnAnEmptyDict(void) {
 
 void test_size_SizeOfNewDictWithOneItemShouldBeOne(void) {
     char *_key = malloc(KEYS_LEN);
-    size_t _data = 0;
+    size_t* _data = 0;
     snprintf(_key, KEYS_LEN, "%s", "0_key");
     pdict_put(D, keys[0], &_data);
     TEST_ASSERT_EQUAL_UINT(pdict_size(D), 1);
@@ -79,7 +79,7 @@ void test_size_ShouldNotBeZeroAfterAddingElements(void) {
 
 void test_add_ShouldAddANewElement(void) {
     char *_key = malloc(KEYS_LEN);
-    size_t _data = 99;
+    size_t* _data = 99;
     snprintf(_key, KEYS_LEN, "%s", "99_key");
     TEST_ASSERT_TRUE(pdict_is_empty(D));
     pdict_put(D, _key, &_data);
@@ -88,9 +88,9 @@ void test_add_ShouldAddANewElement(void) {
 }
 
 void test_append_ShouldAddAnElementToAnEmptyDict(void) {
-    char* _key = malloc(sizeof(char[1][KEYS_LEN]));
+    char* _key = malloc(KEYS_LEN);
     snprintf(_key, KEYS_LEN, "%s", "1_key");
-    size_t _data = 1;
+    size_t* _data = 1;
     TEST_ASSERT_TRUE(pdict_is_empty(D));
     pdict_put(D, _key, _data);
     TEST_ASSERT_FALSE(pdict_is_empty(D));
@@ -124,7 +124,7 @@ void test_get_ShouldGetAllPmapsFromTheDict(void) {
 
     }
     free_keys_data();
-};
+}
 
 void test_remove_ShouldRemoveAllElementsFromDict(void) {
     loadDict();


### PR DESCRIPTION
malloc(sizeof(char[1][KEYS_LEN])) <- malloc(KEYS_LEN) 
size_t <- size_t*
remove misplaced semicolon